### PR TITLE
Fix typo in URL

### DIFF
--- a/example/quick_sniffer.go
+++ b/example/quick_sniffer.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/0x4d31/quick"
+	"github.com/0x4D31/quick"
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcap"


### PR DESCRIPTION
0x4D31 was mispelled in the quick_sniffer.go code